### PR TITLE
Delete user endpoint

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -3,7 +3,7 @@ const log = require('loglevel');
 const HttpError = require('http-errors');
 const { isEmpty } = require('./../services/utils');
 const User = require('./../models/User');
-const { authorizeSession } = require('./../services/auth');
+const { authorizeSession, setClearanceLevel } = require('./../services/auth');
 
 module.exports = () => {
   const router = express.Router();
@@ -66,21 +66,9 @@ module.exports = () => {
     }
   });
 
-
   // edit users
-  router.put('/:userId?', authorizeSession, async (req, res, next) => {
+  router.put('/:userId?', authorizeSession, setClearanceLevel('admin'), async (req, res, next) => {
     try {
-      // are we allowed?
-      const editorUserId = req.stytchAuthenticationInfo.session.user_id;
-      const editor = await User.findOne({ userId: editorUserId });
-
-      if (isEmpty(editor)) {
-        throw HttpError(500, 'Your account is not found in the database!');
-      }
-      if (!User.hasMinimumPermission(editor, 'admin')) {
-        throw HttpError(401, 'You do not have permission to edit!');
-      }
-
       // is the given id a valid format & non-empty?
       const userId = req.params.userId;
       if (!userId || userId === '') {

--- a/routes/users.js
+++ b/routes/users.js
@@ -66,7 +66,6 @@ module.exports = () => {
     }
   });
 
-
   // edit users
   router.put('/:userId?', authorizeSession, async (req, res, next) => {
     try {
@@ -109,9 +108,19 @@ module.exports = () => {
 
   router.delete('/:userId?', authorizeSession, async (req, res, next) => {
     try {
+      const editorUserId = req.stytchAuthenticationInfo.session.user_id;
+      const editor = await User.findOne({ userId: editorUserId });
+
+      if (isEmpty(editor)) {
+        throw HttpError(500, 'Your account is not found in the database!');
+      }
+      if (!User.hasMinimumPermission(editor, 'admin')) {
+        throw HttpError(401, 'You do not have permission to delete!');
+      }
+
       const userId = req.params.userId;
       if (!userId || userId === '') {
-        throw HttpError(400, 'Bad Parameters');
+        throw HttpError(400, 'Required Parameters Missing');
       }
 
       let user = await User.findOne({ userId: userId });

--- a/routes/users.js
+++ b/routes/users.js
@@ -120,7 +120,7 @@ module.exports = () => {
 
       const userId = req.params.userId;
       if (!userId || userId === '') {
-        throw HttpError(400, 'Required Parameters Missing');
+        throw HttpError(400, 'Bad Parameters');
       }
 
       let user = await User.findOne({ userId: userId });

--- a/routes/users.js
+++ b/routes/users.js
@@ -103,7 +103,7 @@ module.exports = () => {
       try {
         const userId = req.params.userId;
         if (!userId || userId === '') {
-          throw HttpError(400, 'Bad Parameters');
+          throw HttpError(400, 'Required Parameters Missing');
         }
 
         let user = await User.findOne({ userId: userId });

--- a/routes/users.test.js
+++ b/routes/users.test.js
@@ -641,7 +641,7 @@ describe('DELETE /users', () => {
       expect(User.deleteUser).not.toBeCalled();
 
       expect(response.statusCode).toBe(400);
-      expect(response.body.error.message).toBe('Bad Parameters');
+      expect(response.body.error.message).toBe('Required Parameters Missing');
     });
 
     test('should respond with a 401 status code when empty string and not authorized', async () => {

--- a/routes/users.test.js
+++ b/routes/users.test.js
@@ -30,10 +30,13 @@ jest.mock('../services/environment', () => {
 });
 
 jest.mock('../services/auth', () => {
+  const { setClearanceLevel } = jest.requireActual('../services/auth');
+
   return {
     authorizeSession: jest.fn().mockImplementation((req, res, next) => {
       return next();
     }),
+    setClearanceLevel,
   };
 });
 
@@ -393,7 +396,7 @@ describe('PUT /users', () => {
       const response = await callPutOnUserRoute(user.userId, desiredChanges);
 
       expect(response.statusCode).toBe(401);
-      expect(response.body.error.message).toBe('You do not have permission to edit!');
+      expect(response.body.error.message).toBe('You are not allowed to do that!');
     });
 
     test('should 404 when the user is not found', async () => {

--- a/routes/users.test.js
+++ b/routes/users.test.js
@@ -638,7 +638,7 @@ describe('DELETE /users', () => {
       expect(User.deleteUser).not.toBeCalled();
 
       expect(response.statusCode).toBe(400);
-      expect(response.body.error.message).toBe('Required Parameters Missing');
+      expect(response.body.error.message).toBe('Bad Parameters');
     });
 
     test('should respond with a 401 status code when empty string and not authorized', async () => {

--- a/routes/users.test.js
+++ b/routes/users.test.js
@@ -657,7 +657,7 @@ describe('DELETE /users', () => {
       expect(User.deleteUser).not.toBeCalled();
 
       expect(response.statusCode).toBe(401);
-      expect(response.body.error.message).toBe('You do not have permission to delete!');
+      expect(response.body.error.message).toBe('You are not allowed to do that!');
     });
   });
 
@@ -731,7 +731,7 @@ describe('DELETE /users', () => {
 
       expect(User.deleteUser).not.toBeCalled();
       expect(response.statusCode).toBe(401);
-      expect(response.body.error.message).toBe('You do not have permission to delete!');
+      expect(response.body.error.message).toBe('You are not allowed to do that!');
     });
   });
 });

--- a/services/auth.js
+++ b/services/auth.js
@@ -25,6 +25,29 @@ async function authorizeSession(req, res, next) {
   }
 }
 
+const { hasMinimumPermission, findOne } = require('../models/User.js');
+const { isEmpty } = require('./../services/utils');
+
+function setClearanceLevel(level) {
+  return async (req, res, next) => {
+    try {
+      const editorUserId = req.stytchAuthenticationInfo.session.user_id;
+      const editor = await findOne({ userId: editorUserId });
+
+      if (isEmpty(editor)) {
+        next(HttpError(500, 'Your account is not found in the database!'));
+      }
+      if (!hasMinimumPermission(editor, level)) {
+        next(HttpError(401, 'You are not allowed to do that!'));
+      }
+      next();
+    } catch (err) {
+      next(HttpError(500, 'An unknown error occurred during authorization!'));
+    }
+  };
+}
+
 module.exports = {
   authorizeSession,
+  setClearanceLevel,
 };


### PR DESCRIPTION
Currently allows everyone to delete users -- this would only allow admins.

It should be noted that I copy-pasted the clearance level checker from the Edit endpoint to pull this off. So we should probably have a clearance checker middleware (see #69 and branch `huseinr2493-feature` for my proof-of-concept).
