### PR TITLE
Improvements, edit course

### DIFF
--- a/docs/developer_jest.md
+++ b/docs/developer_jest.md
@@ -11,10 +11,10 @@ The jest configuration in `package.json` was modified to execute `./jest/tests_c
 
 ### Structure
 
-There is a new folder, `jest`,  in which you'll find
+There is a new folder, `jest`, in which you'll find
 
- - `tests_common.js` — The main pre-test file. It creates a global object called `jest` containing shared helpers + mock generators.
- - `tests_models.js` — Contains model mock generators. These are used by `tests_common`.
+- `tests_common.js` — The main pre-test file. It creates a global object called `jest` containing shared helpers + mock generators.
+- `tests_models.js` — Contains model mock generators. These are used by `tests_common`.
 
 # How it works?
 
@@ -23,42 +23,47 @@ When you use the init functions, it does all the necessary mocks for you and pla
 ### Syntax
 
 First, use init functions.
+
 ```js
 global.jest.init();
 global.jest.init_routes();
 ```
 
 Then you can use this syntax to require mocks or helpers:
+
 ```js
-const {
-	User, request, app, log, env, auth, dataForGetUser
-} = global.jest;
+const { User, request, app, log, env, auth, dataForGetUser } = global.jest;
 ```
 
-If you're testing the real one, don't include it here. For example, don't grab `User` from the global if you're writing `User.test.js` — just `require(...)` it like you normally would.*  
-  
-\* *Also do `init(false)` — see below.*
-  
+If you're testing the real one, don't include it here. For example, don't grab `User` from the global if you're writing `User.test.js` — just `require(...)` it like you normally would.\*
+
+\* _Also do `init(false)` — see below._
+
 ### Functions we can use in all tests now
 
 The most important functions found in `global.jest` are ...
 
 - `init()` - When called, does some setup needed for pretty much all tests (mock environment, disable logging).
-	- Mocks the models. **If you're testing a model, use `init(false)` instead.**
+
+  - Mocks the models. **If you're testing a model, use `init(false)` instead.**
 
 - `init_routes()` - When called, does some setup needed for testing routes. Use this in your route tests.
-	- Mocks authentication. Adds a new function `auth.loginAs(user)` that simulates that user's permissions.
-	- It depends on the `User` mock for authentication, so **run `init()` first.**
+
+  - Mocks authentication. Adds a new function `auth.loginAs(user)` that simulates that user's permissions.
+  - It depends on the `User` mock for authentication, so **run `init()` first.**
 
 - `init_db()` - When called, mocks `db.query`.
-	- If your test needs it,  grab `db` from `global.jest`.
+
+  - If your test needs it, grab `db` from `global.jest`.
 
 - Helper functions like `dataForGetUser` and `dataForGetCourse`.
   - You can add new helpers!
 
 ### How do I mock a new model?
 
-If you wrote a new model, add its mock generator to `tests_models` based on what's there already.
+If you wrote a new model, add its mock generator to `tests_models` based on what's there already.  
+If you added a new function to a model, **be sure to also mock it** in `tests_models`.
 
 # Problems?
+
 If you experience problems with this framework, or if your test is so specialized that it doesn't make any sense to share code, just write it the old way — everything should still work fine.

--- a/docs/developer_jest.md
+++ b/docs/developer_jest.md
@@ -1,0 +1,64 @@
+# New framework for Jest code re-use
+
+See this guide for a rundown on the new Jest helper.  
+You technically don't need to use this, but it should make life easier.
+
+# How it was done
+
+### Environment setup
+
+The jest configuration in `package.json` was modified to execute `./jest/tests_common` before each test suite. This allows tests to use common mocks and helpers without needing to copy-paste them into each test.
+
+### Structure
+
+There is a new folder, `jest`,  in which you'll find
+
+ - `tests_common.js` — The main pre-test file. It creates a global object called `jest` containing shared helpers + mock generators.
+ - `tests_models.js` — Contains model mock generators. These are used by `tests_common`.
+
+# How it works?
+
+When you use the init functions, it does all the necessary mocks for you and places each `require(...)` into `global.jest` so they can be included.
+
+### Syntax
+
+First, use init functions.
+```js
+global.jest.init();
+global.jest.init_routes();
+```
+
+Then you can use this syntax to require mocks or helpers:
+```js
+const {
+	User, request, app, log, env, auth, dataForGetUser
+} = global.jest;
+```
+
+If you're testing the real one, don't include it here. For example, don't grab `User` from the global if you're writing `User.test.js` — just `require(...)` it like you normally would.*  
+  
+\* *Also do `init(false)` — see below.*
+  
+### Functions we can use in all tests now
+
+The most important functions found in `global.jest` are ...
+
+- `init()` - When called, does some setup needed for pretty much all tests (mock environment, disable logging).
+	- Mocks the models. **If you're testing a model, use `init(false)` instead.**
+
+- `init_routes()` - When called, does some setup needed for testing routes. Use this in your route tests.
+	- Mocks authentication. Adds a new function `auth.loginAs(user)` that simulates that user's permissions.
+	- It depends on the `User` mock for authentication, so **run `init()` first.**
+
+- `init_db()` - When called, mocks `db.query`.
+	- If your test needs it,  grab `db` from `global.jest`.
+
+- Helper functions like `dataForGetUser` and `dataForGetCourse`.
+  - You can add new helpers!
+
+### How do I mock a new model?
+
+If you wrote a new model, add its mock generator to `tests_models` based on what's there already.
+
+# Problems?
+If you experience problems with this framework, or if your test is so specialized that it doesn't make any sense to share code, just write it the old way — everything should still work fine.

--- a/jest/tests_common.js
+++ b/jest/tests_common.js
@@ -1,0 +1,152 @@
+const modelMocks = require('./tests_models');
+
+global.jest = {
+  // Initialize Models, environment
+  init: (initModels = true) => {
+    // models
+    if (initModels)
+      for (const mockName of Object.keys(modelMocks)) {
+        global.jest[mockName] = modelMocks[mockName]();
+      }
+    // environment
+    jest.mock('../services/environment', () => {
+      return {
+        port: 3000,
+        stytchProjectId: 'project-test-11111111-1111-1111-1111-111111111111',
+        stytchSecret: 'secret-test-111111111111',
+        masterAdminEmail: 'master@gmail.com',
+      };
+    });
+    // disable logging
+    const log = require('loglevel');
+    beforeAll(() => {
+      log.disableAll();
+    });
+    // log, env
+    global.jest.log = log;
+    global.jest.env = require('../services/environment');
+  },
+
+  // Initialize auth, app
+  init_routes: () => {
+    // mock auth
+    jest.mock('../services/auth', () => {
+      const { setClearanceLevel } = jest.requireActual('../services/auth');
+
+      return {
+        // default login is an unprivileged user
+        authorizeSession: jest.fn().mockImplementation((req, res, next) => {
+          const { sampleStytchAuthenticationInfo, dataForGetUser } = global.jest;
+          req.stytchAuthenticationInfo = sampleStytchAuthenticationInfo(dataForGetUser(1)[0]);
+          return next();
+        }),
+        setClearanceLevel,
+      };
+    });
+    // use real clearance checker, custom login helper
+    // loginAs will take user data as input & set up mocks appropriately
+    global.jest.auth = require('../services/auth');
+    global.jest.auth.loginAs = function (user, dbUser) {
+      // resolve db user
+      global.jest.User.findOne.mockResolvedValueOnce(dbUser !== undefined ? dbUser : user);
+      // resolve stytch data
+      global.jest.auth.authorizeSession.mockImplementationOnce((req, res, next) => {
+        req.stytchAuthenticationInfo = global.jest.sampleStytchAuthenticationInfo(
+          user.userId,
+          user.email
+        );
+        return next();
+      });
+    };
+    // more testing essentials
+    global.jest.request = require('supertest');
+    global.jest.app = require('../app')();
+  },
+
+  // Init for tests using db.query
+  init_db: () => {
+    jest.mock('../services/database.js', () => {
+      return {
+        db: {
+          query: jest.fn(),
+        },
+      };
+    });
+    global.jest.db = require('../services/database').db;
+  },
+
+  // --- miscellaneous helper functions ---
+
+  // a helper that creates an array structure for getCourseById
+  dataForGetCourse: function (rows, offset = 0) {
+    const data = [];
+    for (let i = 1; i <= rows; i++) {
+      const value = i + offset;
+      data.push({
+        id: `${value}`,
+        prefix: 'DEP',
+        suffix: `${100 + i}`,
+        title: 'Introduction to Whatever',
+        description: 'Department consent required',
+        credits: 3,
+      });
+    }
+    return data;
+  },
+  // a helper that creates an array structure for getUserById
+  dataForGetUser: function (rows, offset = 0) {
+    const data = [];
+    for (let i = 1; i <= rows; i++) {
+      const value = i + offset;
+      data.push({
+        id: `${value}`,
+        email: `email${value}@uwstout.edu`,
+        userId: `user-test-someguid${value}`,
+        enable: 'false',
+        role: 'user',
+      });
+    }
+    return data;
+  },
+  // a helper that returns sample auth data -- taken directly from the Stytch API reference
+  sampleStytchAuthenticationInfo: function (userId, email) {
+    return {
+      status_code: 200,
+      request_id: 'request-id-test-b05c992f-ebdc-489d-a754-c7e70ba13141',
+      session: {
+        attributes: {
+          ip_address: '203.0.113.1',
+          user_agent:
+            'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36',
+        },
+        authentication_factors: [
+          {
+            delivery_method: 'email',
+            email_factor: {
+              email_address: `${email}`,
+              email_id: 'email-test-81bf03a8-86e1-4d95-bd44-bb3495224953',
+            },
+            last_authenticated_at: '2021-08-09T07:41:52Z',
+            type: 'magic_link',
+          },
+        ],
+        expires_at: '2021-08-10T07:41:52Z',
+        last_accessed_at: '2021-08-09T07:41:52Z',
+        session_id: 'session-test-fe6c042b-6286-479f-8a4f-b046a6c46509',
+        started_at: '2021-08-09T07:41:52Z',
+        user_id: `${userId}`,
+      },
+      session_token: 'mZAYn5aLEqKUlZ_Ad9U_fWr38GaAQ1oFAhT8ds245v7Q',
+    };
+  },
+  // a helper that returns one admin user row
+  samplePrivilegedUser: function () {
+    return {
+      id: '0',
+      email: 'sandbox@stytch.com',
+      userId: 'user-test-16d9ba61-97a1-4ba4-9720-b03761dc50c6',
+      enable: 'true',
+      role: 'admin',
+    };
+  },
+};

--- a/jest/tests_models.js
+++ b/jest/tests_models.js
@@ -33,6 +33,7 @@ module.exports = {
     jest.mock('../models/Course', () => {
       return {
         findOne: jest.fn(),
+        findAll: jest.fn(),
         deleteCourse: jest.fn(),
         edit: jest.fn(),
         count: jest.fn(),
@@ -41,11 +42,29 @@ module.exports = {
     // add mock resetter
     const Course = require('../models/Course');
     Course.resetAllMocks = function () {
-      for (const mockName of ['findOne', 'deleteCourse', 'edit', 'count']) {
+      for (const mockName of ['findOne', 'findAll', 'deleteCourse', 'edit', 'count']) {
         Course[mockName].mockReset();
         Course[mockName].mockResolvedValue(null);
       }
     };
     return Course;
+  },
+  // Term mocker
+  Term: () => {
+    // do the mock
+    jest.mock('../models/Term', () => {
+      return {
+        count: jest.fn(),
+      };
+    });
+    // add mock resetter
+    const Term = require('../models/Term');
+    Term.resetAllMocks = function () {
+      for (const mockName of ['count']) {
+        Term[mockName].mockReset();
+        Term[mockName].mockResolvedValue(null);
+      }
+    };
+    return Term;
   },
 };

--- a/jest/tests_models.js
+++ b/jest/tests_models.js
@@ -1,0 +1,51 @@
+module.exports = {
+  // User mocker
+  User: () => {
+    // do the mock
+    jest.mock('../models/User', () => {
+      const { hasMinimumPermission } = jest.requireActual('../models/User');
+      return {
+        findOne: jest.fn().mockImplementation((criteria) => {
+          return Object.assign(criteria, global.jest.dataForGetUser(1)[0]);
+        }),
+        findAll: jest.fn(),
+        create: jest.fn(),
+        edit: jest.fn(),
+        hasMinimumPermission,
+        deleteUser: jest.fn(),
+        count: jest.fn(),
+      };
+    });
+
+    // add mock resetter
+    const User = require('../models/User');
+    User.resetAllMocks = function () {
+      for (const mockName of ['findOne', 'findAll', 'create', 'edit', 'deleteUser', 'count']) {
+        User[mockName].mockReset();
+        User[mockName].mockResolvedValue(null);
+      }
+    };
+    return User;
+  },
+  // Course mocker
+  Course: () => {
+    // do the mock
+    jest.mock('../models/Course', () => {
+      return {
+        findOne: jest.fn(),
+        deleteCourse: jest.fn(),
+        edit: jest.fn(),
+        count: jest.fn(),
+      };
+    });
+    // add mock resetter
+    const Course = require('../models/Course');
+    Course.resetAllMocks = function () {
+      for (const mockName of ['findOne', 'deleteCourse', 'edit', 'count']) {
+        Course[mockName].mockReset();
+        Course[mockName].mockResolvedValue(null);
+      }
+    };
+    return Course;
+  },
+};

--- a/models/Course.js
+++ b/models/Course.js
@@ -1,24 +1,20 @@
 const HttpError = require('http-errors');
 const { db } = require('../services/database');
 const { whereParams } = require('../services/sqltools');
+const { isEmpty } = require('../services/utils');
 
 // if found return { ... }
 // if not found return {}
 // if db error, db.query will throw a rejected promise
-async function findOne(id) {
-  if (id) {
-    const { text, params } = whereParams({
-      id: id,
-    });
-
-    const res = await db.query(`SELECT * from "course" ${text} LIMIT 1;`, params);
-    if (res.rows.length > 0) {
-      return res.rows[0];
-    }
-  } else {
-    throw HttpError(400, 'Id is required.');
+async function findOne(criteria) {
+  if (!criteria || isEmpty(criteria)) {
+    throw HttpError.BadRequest('Id is required.');
   }
-
+  const { text, params } = whereParams(criteria);
+  const res = await db.query(`SELECT * from "course" ${text} LIMIT 1;`, params);
+  if (res.rows.length > 0) {
+    return res.rows[0];
+  }
   return {};
 }
 
@@ -26,9 +22,7 @@ async function findOne(id) {
 async function deleteCourse(id) {
   // check that id is not nullable
   if (id) {
-    const { text, params } = whereParams({
-      id: id,
-    });
+    const { text, params } = whereParams({ id });
 
     const res = await db.query(`DELETE FROM "course" ${text};`, params);
     if (res.rows.length > 0) {

--- a/models/Course.test.js
+++ b/models/Course.test.js
@@ -27,9 +27,11 @@ function dataForGetCourse(rows, offset = 0) {
     const value = i + offset;
     data.push({
       id: `${value}`,
-      department: 'DEP',
-      number: `${value}`,
-      credits: '3',
+      prefix: 'DEP',
+      suffix: `${100 + i}`,
+      title: 'Introduction to Whatever',
+      description: 'Department consent required',
+      credits: 3,
     });
   }
   return data;
@@ -47,34 +49,34 @@ describe('Course Model', () => {
       const id = data[0].id;
 
       db.query.mockResolvedValue({ rows: data });
-      await Course.findOne(id);
+      await Course.findOne({ id });
 
       expect(db.query.mock.calls).toHaveLength(1);
       expect(db.query.mock.calls[0][1][0]).toBe(id);
     });
 
     test('should return a single Course', async () => {
-      const data = dataForGetCourse(1);
-      const id = data[0].id;
+      const row = dataForGetCourse(1)[0];
+      const id = row.id;
 
-      db.query.mockResolvedValue({ rows: [data] });
-      const course = await Course.findOne(id);
+      db.query.mockResolvedValue({ rows: [row] });
+      const course = await Course.findOne({ id });
 
-      for (const key in Object.keys(data)) {
-        expect(course).toHaveProperty(key, data[key]);
+      for (const key in Object.keys(row)) {
+        expect(course).toHaveProperty(key, row[key]);
       }
     });
 
     test('should return empty for unfound course', async () => {
       db.query.mockResolvedValue({ rows: [] });
-      const course = await Course.findOne(123);
+      const course = await Course.findOne({ id: 123 });
 
       expect(Object.keys(course)).toHaveLength(0);
     });
 
     test('should throw error for database error', async () => {
       db.query.mockRejectedValueOnce(new Error('a testing database error'));
-      await expect(Course.findOne(123)).rejects.toThrowError('a testing database error');
+      await expect(Course.findOne({ id: 123 })).rejects.toThrowError('a testing database error');
     });
 
     test('should throw error if no parameters', async () => {

--- a/models/Course.test.js
+++ b/models/Course.test.js
@@ -1,41 +1,8 @@
-const log = require('loglevel');
-const { db } = require('../services/database');
+global.jest.init(false); // Init without models
+global.jest.init_db();
+const { dataForGetCourse, db } = global.jest;
+
 const Course = require('./Course');
-
-beforeAll(() => {
-  log.disableAll();
-});
-
-jest.mock('../services/database.js', () => {
-  return {
-    db: {
-      query: jest.fn(),
-    },
-  };
-});
-
-jest.mock('../services/environment.js', () => {
-  return {
-    masterAdminEmail: 'master@gmail.com',
-  };
-});
-
-// a helper that creates an array structure for getCourseById
-function dataForGetCourse(rows, offset = 0) {
-  const data = [];
-  for (let i = 1; i <= rows; i++) {
-    const value = i + offset;
-    data.push({
-      id: `${value}`,
-      prefix: 'DEP',
-      suffix: `${100 + i}`,
-      title: 'Introduction to Whatever',
-      description: 'Department consent required',
-      credits: 3,
-    });
-  }
-  return data;
-}
 
 describe('Course Model', () => {
   beforeEach(() => {
@@ -121,7 +88,7 @@ describe('Course Model', () => {
   });
 
   describe('Count Courses', () => {
-    test('One User in the Database', async () => {
+    test('One Course in the Database', async () => {
       db.query.mockResolvedValue({ rows: [{ count: 1 }] });
       const res = await Course.count();
       expect(db.query.mock.calls).toHaveLength(1);
@@ -129,5 +96,80 @@ describe('Course Model', () => {
       expect(db.query.mock.calls[0][0]).toBe(`SELECT COUNT(*) FROM "course"`);
       expect(res).toHaveProperty('count', 1);
     });
+  });
+});
+describe('editing a course', () => {
+  beforeEach(() => {
+    db.query.mockReset();
+    db.query.mockResolvedValue(null);
+  });
+
+  test('Course.edit', async () => {
+    const data = dataForGetCourse(1);
+    const row = data[0];
+    row.credits = 1;
+    row.prefix = 'CS';
+    const newValues = { credits: row.credits, prefix: row.prefix };
+
+    db.query.mockResolvedValue({ rows: data });
+    const course = await Course.edit(row.id, newValues);
+
+    expect(db.query.mock.calls).toHaveLength(1);
+    expect(db.query.mock.calls[0]).toHaveLength(2);
+    expect(db.query.mock.calls[0][0]).toBe(
+      'UPDATE "course" SET "credits"=$2, "prefix"=$3 WHERE "id"=$1 RETURNING *;'
+    );
+    console.log(db.query.mock.calls);
+    expect(db.query.mock.calls[0][1]).toHaveLength(3);
+    expect(db.query.mock.calls[0][1][0]).toBe(row.id);
+    expect(db.query.mock.calls[0][1][1]).toBe(row.credits);
+    expect(db.query.mock.calls[0][1][2]).toBe(row.prefix);
+    for (const key in Object.keys(row)) {
+      expect(course).toHaveProperty(key, row[key]);
+    }
+  });
+
+  test('Course.edit with database error', async () => {
+    const data = dataForGetCourse(1);
+    const row = data[0];
+    row.credits = 1;
+    row.prefix = 'CS';
+    const newValues = { credits: row.credits, prefix: row.prefix };
+
+    // error thrown during call to db query
+    db.query.mockRejectedValueOnce(new Error('a testing database error'));
+    await expect(Course.edit(row.id, newValues)).rejects.toThrowError('a testing database error');
+
+    expect(db.query.mock.calls).toHaveLength(1);
+    expect(db.query.mock.calls[0]).toHaveLength(2);
+    expect(db.query.mock.calls[0][0]).toBe(
+      'UPDATE "course" SET "credits"=$2, "prefix"=$3 WHERE "id"=$1 RETURNING *;'
+    );
+    console.log(db.query.mock.calls);
+    expect(db.query.mock.calls[0][1]).toHaveLength(3);
+    expect(db.query.mock.calls[0][1][0]).toBe(row.id);
+    expect(db.query.mock.calls[0][1][1]).toBe(row.credits);
+    expect(db.query.mock.calls[0][1][2]).toBe(row.prefix);
+  });
+
+  test('Course.edit with bad input', async () => {
+    await expect(Course.edit('id', 'bad input')).rejects.toThrowError('Id is required.');
+    expect(db.query.mock.calls).toHaveLength(0);
+  });
+
+  test('Course.edit with no input', async () => {
+    await expect(Course.edit()).rejects.toThrowError('Id is required.');
+    expect(db.query.mock.calls).toHaveLength(0);
+  });
+});
+
+describe('Count Courses', () => {
+  test('One Course in the Database', async () => {
+    db.query.mockResolvedValue({ rows: [{ count: 1 }] });
+    const res = await Course.count();
+    expect(db.query.mock.calls).toHaveLength(1);
+    expect(db.query.mock.calls[0]).toHaveLength(1);
+    expect(db.query.mock.calls[0][0]).toBe(`SELECT COUNT(*) FROM "course"`);
+    expect(res).toHaveProperty('count', 1);
   });
 });

--- a/models/Term.test.js
+++ b/models/Term.test.js
@@ -1,24 +1,8 @@
-const log = require('loglevel');
-const { db } = require('../services/database');
+global.jest.init(false);
+global.jest.init_db();
+
+const { db } = global.jest;
 const Term = require('./Term');
-
-beforeAll(() => {
-  log.disableAll();
-});
-
-jest.mock('../services/database.js', () => {
-  return {
-    db: {
-      query: jest.fn(),
-    },
-  };
-});
-
-jest.mock('../services/environment.js', () => {
-  return {
-    masterAdminEmail: 'master@gmail.com',
-  };
-});
 
 describe('Course Model', () => {
   beforeEach(() => {

--- a/models/User.js
+++ b/models/User.js
@@ -76,7 +76,7 @@ async function deleteUser(userId) {
 
     const res = await db.query(`DELETE FROM "user" ${text};`, params);
     if (res.rows.length > 0) {
-      return 'the user was deleted';
+      return true;
     }
   } else {
     throw HttpError(400, 'UserId is required.');

--- a/models/User.js
+++ b/models/User.js
@@ -6,7 +6,8 @@ const env = require('../services/environment');
 
 // permission levels
 const rolePermissions = {
-  admin: 999,
+  admin: 99999,
+  director: 100,
   user: 0,
 };
 

--- a/models/User.test.js
+++ b/models/User.test.js
@@ -1,41 +1,8 @@
-const log = require('loglevel');
-const { db } = require('../services/database');
-const env = require('../services/environment');
+global.jest.init(false); // Init without models
+global.jest.init_db();
+const { dataForGetUser, db, env } = global.jest;
+
 const User = require('./User');
-
-beforeAll(() => {
-  log.disableAll();
-});
-
-jest.mock('../services/database.js', () => {
-  return {
-    db: {
-      query: jest.fn(),
-    },
-  };
-});
-
-jest.mock('../services/environment.js', () => {
-  return {
-    masterAdminEmail: 'master@gmail.com',
-  };
-});
-
-// a helper that creates an array structure for getUserById
-function dataForGetUser(rows, offset = 0) {
-  const data = [];
-  for (let i = 1; i <= rows; i++) {
-    const value = i + offset;
-    data.push({
-      id: `${value}`,
-      email: `email${value}@uwstout.edu`,
-      userId: `user-test-someguid${value}`,
-      enable: 'true',
-      role: 'user',
-    });
-  }
-  return data;
-}
 
 describe('User Model', () => {
   beforeEach(() => {

--- a/models/User.test.js
+++ b/models/User.test.js
@@ -281,7 +281,7 @@ describe('User Model', () => {
       expect(db.query.mock.calls[0][0]).toBe('DELETE FROM "user" WHERE "userId"=$1;');
       expect(db.query.mock.calls[0][1]).toHaveLength(1);
       expect(db.query.mock.calls[0][1][0]).toBe(userId);
-      expect(deleteUser).toBe('the user was deleted');
+      expect(deleteUser).toBe(true);
     });
 
     test('User.deleteUser with database error', async () => {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,12 @@
       "services/environment.js",
       "./server.js"
     ],
+    "setupFilesAfterEnv": [
+      "./jest/tests_common"
+    ],
+    "testPathIgnorePatterns": [
+      "jest/*"
+    ],
     "coverageThreshold": {
       "global": {
         "lines": 90

--- a/routes/count.test.js
+++ b/routes/count.test.js
@@ -1,46 +1,7 @@
-const HttpError = require('http-errors');
-const log = require('loglevel');
-const request = require('supertest');
-const app = require('../app')();
-
-const User = require('../models/User');
-const Course = require('../models/Course');
-
-beforeAll(() => {
-  log.disableAll();
-});
-
-jest.mock('../models/User', () => {
-  return {
-    count: jest.fn(),
-  };
-});
-
-jest.mock('../models/Course', () => {
-  return {
-    count: jest.fn(),
-  };
-});
-
-jest.mock('../services/environment', () => {
-  return {
-    port: 3001,
-    stytchProjectId: 'project-test-11111111-1111-1111-1111-111111111111',
-    stytchSecret: 'secret-test-111111111111',
-    masterAdminEmail: 'master@gmail.com',
-  };
-});
-
-jest.mock('../services/auth', () => {
-  return {
-    authorizeSession: jest.fn().mockImplementation((req, res, next) => {
-      return next();
-    }),
-    setClearanceLevel: jest.fn().mockImplementation((level) => (req, res, next) => {
-      return next();
-    }),
-  };
-});
+// Must be at the top. Provided by jest/tests_common
+global.jest.init();
+global.jest.init_routes();
+const { User, Course, app, request } = global.jest;
 
 describe('GET /count (users)', () => {
   beforeEach(() => {
@@ -103,7 +64,7 @@ describe('GET /count (courses)', () => {
       expect(response.statusCode).toBe(404);
     });
     test('if there is an error thrown by the model', async () => {
-      Course.count.mockRejectedValueOnce(HttpError(500, 'Some Error Occurred'));
+      Course.count.mockRejectedValueOnce(new Error('Some Error Occurred'));
       const row = [{ count: 0 }];
       const response = await callGetOnCountRoute(row, 'courses');
       expect(response.statusCode).toBe(500);

--- a/routes/count.test.js
+++ b/routes/count.test.js
@@ -1,3 +1,4 @@
+const HttpError = require('http-errors');
 const log = require('loglevel');
 const request = require('supertest');
 const app = require('../app')();
@@ -54,19 +55,19 @@ describe('GET /count (users)', () => {
 
   describe('user count', () => {
     test('if there is one user in the table', async () => {
-      const row = [{ count: 1 }];
-      await callGetOnCountRoute(row, 'users');
-      expect(row).toHaveLength(1);
-      expect(row[0]).toHaveProperty('count', 1);
+      const row = { count: 1 };
+      const response = await callGetOnCountRoute(row, 'users');
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toHaveProperty('count', 1);
     });
     test('if there is zero users in the table', async () => {
-      const row = [{ count: 0 }];
-      await callGetOnCountRoute(row, 'users');
-      expect(row).toHaveLength(1);
-      expect(row[0]).toHaveProperty('count', 0);
+      const row = { count: 0 };
+      const response = await callGetOnCountRoute(row, 'users');
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toHaveProperty('count', 0);
     });
     test('if the table does not exist', async () => {
-      const row = [{ count: 1 }];
+      const row = { count: 1 };
       const response = await callGetOnCountRoute(row, 'foo');
       expect(response.statusCode).toBe(404);
     });
@@ -85,21 +86,29 @@ describe('GET /count (courses)', () => {
   }
   describe('course count', () => {
     test('if there is one course in the table', async () => {
-      const row = [{ count: 1 }];
-      await callGetOnCountRoute(row, 'courses');
-      expect(row).toHaveLength(1);
-      expect(row[0]).toHaveProperty('count', 1);
+      const row = { count: 1 };
+      const response = await callGetOnCountRoute(row, 'courses');
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toHaveProperty('count', 1);
     });
     test('if there is zero courses in the table', async () => {
-      const row = [{ count: 0 }];
-      await callGetOnCountRoute(row, 'courses');
-      expect(row).toHaveLength(1);
-      expect(row[0]).toHaveProperty('count', 0);
+      const row = { count: 0 };
+      const response = await callGetOnCountRoute(row, 'courses');
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toHaveProperty('count', 0);
     });
     test('if the table does not exist', async () => {
-      const row = [{ count: 1 }];
+      const row = { count: 1 };
       const response = await callGetOnCountRoute(row, 'foo');
       expect(response.statusCode).toBe(404);
+    });
+    test('if there is an error thrown by the model', async () => {
+      Course.count.mockRejectedValueOnce(HttpError(500, 'Some Error Occurred'));
+      const row = [{ count: 0 }];
+      const response = await callGetOnCountRoute(row, 'courses');
+      expect(response.statusCode).toBe(500);
+      expect(response.body.error).not.toBeFalsy();
+      expect(response.body.error.message).toBe('Some Error Occurred');
     });
   });
 });

--- a/routes/count.test.js
+++ b/routes/count.test.js
@@ -1,8 +1,7 @@
-
 // Must be at the top. Provided by jest/tests_common
 global.jest.init();
 global.jest.init_routes();
-const { User, Course, app, request } = global.jest;
+const { User, Term, Course, app, request } = global.jest;
 
 describe('GET /count (users)', () => {
   beforeEach(() => {

--- a/routes/course.js
+++ b/routes/course.js
@@ -11,7 +11,7 @@ module.exports = () => {
   router.get('/:courseId', authorizeSession, async (req, res, next) => {
     try {
       const courseId = req.params.courseId;
-      const course = await Course.findOne(courseId);
+      const course = await Course.findOne({ id: courseId });
       if (isEmpty(course)) {
         throw new HttpError.NotFound();
       }

--- a/routes/course.js
+++ b/routes/course.js
@@ -3,7 +3,7 @@ const log = require('loglevel');
 const HttpError = require('http-errors');
 const { isEmpty } = require('./../services/utils');
 const Course = require('./../models/Course');
-const { authorizeSession } = require('./../services/auth');
+const { authorizeSession, setClearanceLevel } = require('./../services/auth');
 
 module.exports = () => {
   const router = express.Router();
@@ -17,6 +17,37 @@ module.exports = () => {
       }
       log.info(`${req.method} ${req.originalUrl} success: returning course ${courseId}`);
       return res.send(course);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.put('/:id?', authorizeSession, setClearanceLevel('director'), async (req, res, next) => {
+    try {
+      // is the given id a valid format & non-empty?
+      const id = req.params.id;
+      if (!id || id === '') {
+        throw HttpError(400, 'Required Parameters Missing');
+      }
+      const course = await Course.findOne({ id });
+
+      // make sure exists
+      if (isEmpty(course)) {
+        throw new HttpError.NotFound();
+      }
+
+      // perform the edit
+      const editResult = await Course.edit(id, {
+        prefix: req.body.prefix || course.prefix,
+        suffix: req.body.suffix || course.suffix,
+        title: req.body.title || course.title,
+        description: req.body.description || course.description,
+        credits: req.body.credits || course.credits,
+      });
+
+      // success
+      log.info(`${req.method} ${req.originalUrl} success: returning edited course ${editResult}`);
+      return res.send(editResult);
     } catch (error) {
       next(error);
     }

--- a/routes/course.test.js
+++ b/routes/course.test.js
@@ -33,15 +33,18 @@ jest.mock('../services/auth', () => {
   };
 });
 
+// a helper that creates an array structure for getCourseById
 function dataForGetCourse(rows, offset = 0) {
   const data = [];
   for (let i = 1; i <= rows; i++) {
     const value = i + offset;
     data.push({
       id: `${value}`,
-      department: 'DEP',
-      number: `${value}`,
-      credits: '3',
+      prefix: 'DEP',
+      suffix: `${100 + i}`,
+      title: 'Introduction to Whatever',
+      description: 'Department consent required',
+      credits: 3,
     });
   }
   return data;
@@ -67,17 +70,17 @@ describe('GET /course', () => {
       await callGetOnCourseRoute(row);
       expect(Course.findOne.mock.calls).toHaveLength(1);
       expect(Course.findOne.mock.calls[0]).toHaveLength(1);
-      expect(Course.findOne.mock.calls[0][0]).toBe(row.id);
+      expect(Course.findOne.mock.calls[0][0]).toHaveProperty('id', row.id);
     });
 
     test('should respond with a json object containing the course data', async () => {
       const data = dataForGetCourse(10);
       for (const row of data) {
         const { body: course } = await callGetOnCourseRoute(row);
-        expect(course.id).toBe(row.id);
-        expect(course.department).toBe(row.department);
-        expect(course.number).toBe(row.number);
-        expect(course.credits).toBe(row.credits);
+
+        for (const key in Object.keys(row)) {
+          expect(course).toHaveProperty(key, row[key]);
+        }
       }
     });
 

--- a/routes/course.test.js
+++ b/routes/course.test.js
@@ -1,60 +1,17 @@
-const log = require('loglevel');
-const request = require('supertest');
-const app = require('../app')();
-const Course = require('../models/Course');
+// Must be at the top. Provided by jest/tests_common
+global.jest.init();
+global.jest.init_routes();
+const { Course, auth, app, request, dataForGetCourse, dataForGetUser, samplePrivilegedUser } =
+  global.jest;
 
-beforeAll(() => {
-  log.disableAll();
-});
-
-jest.mock('../models/Course', () => {
-  return {
-    findOne: jest.fn(),
-  };
-});
-
-jest.mock('../services/environment', () => {
-  return {
-    port: 3001,
-    stytchProjectId: 'project-test-11111111-1111-1111-1111-111111111111',
-    stytchSecret: 'secret-test-111111111111',
-    masterAdminEmail: 'master@gmail.com',
-  };
-});
-
-jest.mock('../services/auth', () => {
-  const { setClearanceLevel } = jest.requireActual('../services/auth');
-
-  return {
-    authorizeSession: jest.fn().mockImplementation((req, res, next) => {
-      return next();
-    }),
-    setClearanceLevel,
-  };
-});
-
-// a helper that creates an array structure for getCourseById
-function dataForGetCourse(rows, offset = 0) {
-  const data = [];
-  for (let i = 1; i <= rows; i++) {
-    const value = i + offset;
-    data.push({
-      id: `${value}`,
-      prefix: 'DEP',
-      suffix: `${100 + i}`,
-      title: 'Introduction to Whatever',
-      description: 'Department consent required',
-      credits: 3,
-    });
-  }
-  return data;
-}
+/*
+Custom extensions defined in test_models
+- Course.resetAllMocks()
+- auth.loginAs(user, [dbUser - optional])
+*/
 
 describe('GET /course', () => {
-  beforeEach(() => {
-    Course.findOne.mockReset();
-    Course.findOne.mockResolvedValue(null);
-  });
+  beforeEach(Course.resetAllMocks);
 
   // helper functions - id is a numeric value
   async function callGetOnCourseRoute(row, key = 'id') {
@@ -106,6 +63,167 @@ describe('GET /course', () => {
       Course.findOne.mockRejectedValueOnce(new Error('Some Database Error'));
       const response = await request(app).get(`/course/100`);
       expect(response.statusCode).toBe(500);
+    });
+  });
+});
+
+describe('PUT /course', () => {
+  // TODO double check acceptance criteria
+  beforeEach(Course.resetAllMocks);
+
+  // put helper
+  async function callPutOnCourseRoute(courseId, body) {
+    const response = await request(app).put(`/course/${courseId}`).send(body);
+    return response;
+  }
+
+  describe('given an empty URL bar', () => {
+    test('should result in 400', async () => {
+      const editor = samplePrivilegedUser();
+      auth.loginAs(editor);
+
+      Course.findOne.mockResolvedValueOnce({});
+      const response = await callPutOnCourseRoute('', {}); // NO COURSE ID
+
+      expect(Course.findOne).not.toBeCalled();
+      expect(response.statusCode).toBe(400);
+      expect(response.body.error.message).toBe('Required Parameters Missing');
+    });
+  });
+
+  describe('when URL bar is non-empty', () => {
+    test('should 500 when course is not found', async () => {
+      const editor = samplePrivilegedUser();
+      auth.loginAs(editor, {}); // NO EDITOR IN DB
+
+      const course = dataForGetCourse(1)[0];
+
+      const desiredChanges = {
+        prefix: 'ANTH',
+        suffix: '220HON',
+        title: 'Cultural Anthropology',
+      };
+
+      Course.findOne.mockResolvedValueOnce(course);
+      Course.edit.mockResolvedValueOnce(Object.assign(course, desiredChanges));
+
+      const response = await callPutOnCourseRoute(course.id, desiredChanges);
+
+      expect(response.statusCode).toBe(500);
+      expect(response.body.error.message).toBe('Your account is not found in the database!');
+    });
+
+    test('should 401 when not authorized to edit courses', async () => {
+      const editor = dataForGetUser(1)[0];
+      editor.enable = 'true';
+      auth.loginAs(editor); // Unprivileged editor
+
+      const course = dataForGetCourse(1)[0];
+
+      const desiredChanges = {
+        prefix: 'ANTH',
+        suffix: '220HON',
+        title: 'Cultural Anthropology',
+      };
+
+      Course.findOne.mockResolvedValueOnce(course);
+      Course.edit.mockResolvedValueOnce(Object.assign(course, desiredChanges));
+
+      const response = await callPutOnCourseRoute(course.id, desiredChanges);
+
+      expect(response.statusCode).toBe(401);
+      expect(response.body.error.message).toBe('You are not allowed to do that!');
+    });
+
+    test('should 404 when the course is not found', async () => {
+      const editor = samplePrivilegedUser();
+      auth.loginAs(editor);
+
+      const desiredChanges = {
+        prefix: 'ANTH',
+        suffix: '220HON',
+        title: 'Cultural Anthropology',
+      };
+
+      Course.findOne.mockResolvedValueOnce({}); // NO COURSE
+      Course.edit.mockResolvedValueOnce({});
+
+      const response = await callPutOnCourseRoute(1, desiredChanges);
+      expect(response.statusCode).toBe(404);
+      expect(Course.edit).not.toBeCalled();
+      expect(response.body.error.message).toBe('Not Found');
+    });
+
+    test('should respond 200 and successfully return edited version of user', async () => {
+      const editor = samplePrivilegedUser();
+      auth.loginAs(editor);
+
+      const course = dataForGetCourse(1)[0];
+
+      const desiredChanges = {
+        prefix: 'ANTH',
+        suffix: '220HON',
+        title: 'Cultural Anthropology',
+      };
+
+      Course.findOne.mockResolvedValueOnce(course);
+      const expectedReturn = Object.assign(course, desiredChanges);
+      Course.edit.mockResolvedValueOnce(desiredChanges);
+
+      const response = await callPutOnCourseRoute(course.id, desiredChanges);
+
+      expect(response.statusCode).toBe(200);
+      // check all properties
+      for (const key of Object.keys(response.body)) {
+        expect(response.body).toHaveProperty(key, expectedReturn[key]);
+      }
+    });
+
+    test('should still work even if no body parameters are specified', async () => {
+      const editor = samplePrivilegedUser();
+      auth.loginAs(editor);
+
+      const course = dataForGetCourse(1)[0];
+
+      const desiredChanges = {};
+
+      Course.findOne.mockResolvedValueOnce(course);
+      const expectedReturn = Object.assign(course, desiredChanges);
+      Course.edit.mockResolvedValueOnce(desiredChanges);
+
+      const response = await callPutOnCourseRoute(course.id, desiredChanges);
+
+      expect(response.statusCode).toBe(200);
+      // check all properties
+      for (const key of Object.keys(response.body)) {
+        expect(response.body).toHaveProperty(key, expectedReturn[key]);
+      }
+    });
+
+    test("should still work if the user's role is Director", async () => {
+      const editor = samplePrivilegedUser();
+      editor.role = 'director';
+      auth.loginAs(editor);
+
+      const course = dataForGetCourse(1)[0];
+
+      const desiredChanges = {
+        prefix: 'ANTH',
+        suffix: '220HON',
+        title: 'Cultural Anthropology',
+      };
+
+      Course.findOne.mockResolvedValueOnce(course);
+      const expectedReturn = Object.assign(course, desiredChanges);
+      Course.edit.mockResolvedValueOnce(desiredChanges);
+
+      const response = await callPutOnCourseRoute(course.id, desiredChanges);
+
+      expect(response.statusCode).toBe(200);
+      // check all properties
+      for (const key of Object.keys(response.body)) {
+        expect(response.body).toHaveProperty(key, expectedReturn[key]);
+      }
     });
   });
 });

--- a/routes/index.test.js
+++ b/routes/index.test.js
@@ -11,4 +11,11 @@ describe('Index Route Tests', () => {
     const response = await request(app).get('/doesnotexists');
     expect(response.statusCode).toBe(404);
   });
+  test('check health route', async () => {
+    const response = await request(app).get('/health');
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toHaveProperty('uptime');
+    expect(response.body).toHaveProperty('date');
+    expect(response.body).toHaveProperty('message', 'Ok');
+  });
 });

--- a/routes/users.test.js
+++ b/routes/users.test.js
@@ -440,6 +440,25 @@ describe('PUT /users', () => {
       expect(response.statusCode).toBe(200);
       expect(response.body).toEqual(expectedReturn);
     });
+
+    test('should still work even if no body parameters are specified', async () => {
+      const editor = samplePrivilegedUser();
+      const user = dataForGetUser(1)[0];
+
+      const desiredChanges = {};
+
+      resolveAuthToMatchUser(editor);
+
+      User.findOne.mockResolvedValueOnce(editor);
+      User.findOne.mockResolvedValueOnce(user);
+
+      User.edit.mockResolvedValueOnce(user);
+
+      const response = await callPutOnUserRoute(user.userId, desiredChanges);
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toEqual(user);
+    });
   });
 });
 

--- a/services/auth.test.js
+++ b/services/auth.test.js
@@ -1,19 +1,8 @@
-const log = require('loglevel');
+global.jest.init(false); // Init without models
+
 const stytchwrapper = require('./stytchwrapper');
 const auth = require('./auth');
 const { getMockReq, getMockRes } = require('@jest-mock/express');
-
-beforeAll(() => {
-  log.disableAll();
-});
-
-jest.mock('./environment', () => {
-  return {
-    stytchProjectId: 'project-test-11111111-1111-1111-1111-111111111111',
-    stytchSecret: 'secret-test-111111111111',
-    stytchEnv: 'test',
-  };
-});
 
 jest.mock('./stytchwrapper', () => {
   return {


### PR DESCRIPTION
There are a lot of changes here ...
- Added edit course function
- Added edit course endpoint (clearance level: `director`)
  - Added `'director'` role to permission checker
- **Code is now re-used between unit tests** - 89499ee0ec57817bf798b5b480746499a24ca2ff
- Made User delete function return `true` for consistency reasons
- Made it so endpoints in the `/count` route are populated using a for loop
- Fixed a validity issue / bug with count endpoint tests
- Added tests and refactored to achieve near-100% Jest coverage